### PR TITLE
Looting now properly affects drop amount

### DIFF
--- a/src/main/java/net/o2gaming/carbon/listeners/ItemListener.java
+++ b/src/main/java/net/o2gaming/carbon/listeners/ItemListener.java
@@ -6,6 +6,7 @@ import net.o2gaming.carbon.Carbon;
 
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Ageable;
+import org.bukkit.entity.Arrow;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -37,18 +38,27 @@ public class ItemListener implements Listener {
                     Ageable entity = (Ageable) event.getEntity();
                     if(entity.isAdult()) {
                         boolean fireaspect = false;
+                        int looting = 1;
                         if(entity.getLastDamageCause() instanceof EntityDamageByEntityEvent) {
                             EntityDamageByEntityEvent dEvent = (EntityDamageByEntityEvent) entity.getLastDamageCause();
                             if(dEvent.getDamager() != null && dEvent.getDamager() instanceof Player) {
                                 ItemStack hand = ((Player) dEvent.getDamager()).getItemInHand();
                                 fireaspect = hand.containsEnchantment(Enchantment.FIRE_ASPECT);
+                                if(hand.containsEnchantment(Enchantment.LOOT_BONUS_MOBS))
+                                    looting += hand.getEnchantmentLevel(Enchantment.LOOT_BONUS_MOBS);
+                                if(looting < 1) //Incase a plugin sets an enchantment level to be negative
+                                    looting = 1;
+                            } else if(dEvent.getDamager() != null && dEvent.getDamager() instanceof Arrow) {
+                                Arrow a = (Arrow) dEvent.getDamager();
+                                if(a.getFireTicks() > 0)
+                                    fireaspect = true;
                             }
                         }
                         if(entity.getLastDamageCause().getCause().equals(DamageCause.FIRE_TICK) || entity.getLastDamageCause().getCause().equals(DamageCause.FIRE) ||
                                 entity.getLastDamageCause().getCause().equals(DamageCause.LAVA) || fireaspect)
-                            event.getDrops().add(new ItemStack(Carbon.injector().cookedMuttonItemMat, random.nextInt(1) + 1));
+                            event.getDrops().add(new ItemStack(Carbon.injector().cookedMuttonItemMat, random.nextInt(2) + 1 + random.nextInt(looting)));
                         else
-                            event.getDrops().add(new ItemStack(Carbon.injector().muttonItemMat, random.nextInt(1) + 1));
+                            event.getDrops().add(new ItemStack(Carbon.injector().muttonItemMat, random.nextInt(2) + 1 + random.nextInt(looting)));
                     }
                 }
             }


### PR DESCRIPTION
Flame bows also now drop cooked mutton, as well as dropping 1-2 by default as in vanilla instead of just dropping 1 every time.
