### PR TITLE
Stops or restarts server upon /reload

### DIFF
--- a/src/main/java/com/lastabyss/carbon/Carbon.java
+++ b/src/main/java/com/lastabyss/carbon/Carbon.java
@@ -1,11 +1,8 @@
-
 package com.lastabyss.carbon;
-
-import com.lastabyss.carbon.external.support.NoCheatPlusSupporter;
-import java.util.logging.Logger;
 
 import com.lastabyss.carbon.generator.CarbonWorldGenerator;
 import com.lastabyss.carbon.listeners.BlockListener;
+import com.lastabyss.carbon.listeners.CommandListener;
 import com.lastabyss.carbon.listeners.ItemListener;
 import com.lastabyss.carbon.listeners.WorldBorderListener;
 import com.lastabyss.carbon.protocolblocker.ProtocolBlocker;
@@ -17,96 +14,109 @@ import com.lastabyss.carbon.utils.Utilities;
 import com.lastabyss.carbon.worldborder.WorldBorder;
 
 import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.util.logging.Logger;
 
 public class Carbon extends JavaPlugin {
 
   private BlockListener blockListener = new BlockListener();
+  private CommandListener commandListener = new CommandListener();
   private ItemListener itemListener = new ItemListener(this);
   private WorldBorderListener worldBorderListener = new WorldBorderListener();
+
   private ProtocolBlocker protocolBlocker = new ProtocolBlocker(this);
   private CarbonWorldGenerator worldGenerator = new CarbonWorldGenerator(this);
-  public static final Logger log = Logger.getLogger("minecraft");
+
+  private PluginDescriptionFile pluginDescriptionFile = this.getDescription();
+  private FileConfiguration spigot = YamlConfiguration.loadConfiguration(new File(getServer().getWorldContainer(), "spigot.yml"));
+
+  public static final Logger log = Bukkit.getLogger();
+
   private static Injector injector;
   private double localConfigVersion = 0.1;
-  
-    @Override
-    public void onLoad() {
-    	//call to server shutdown if worlds are already loaded, prevents various errors when loading plugin on the fly
-    	if (!Bukkit.getWorlds().isEmpty()) {
-    		Bukkit.shutdown();
-    		return;
-    	}
-    	//inject new blocks
-        try {
-          DynamicEnumType.loadReflection();
-        }
-        catch (NoSuchMethodException|SecurityException|ClassNotFoundException|IllegalAccessException|IllegalArgumentException|java.lang.reflect.InvocationTargetException e) {
-          e.printStackTrace();
-        }
-        injector = new Injector();
-        injector.registerAll();
-        injector.registerRecipes();
-        
-        log.info("Carbon has finished injecting all 1.8 functionalities.");
+
+  @Override
+  public void onLoad() {
+    //call to server shutdown if worlds are already loaded, prevents various errors when loading plugin on the fly
+    if (!Bukkit.getWorlds().isEmpty()) {
+      log.severe("World loaded before" + pluginDescriptionFile.getName() + " "
+                 + pluginDescriptionFile.getVersion() + "! (Was " + pluginDescriptionFile.getName()
+                 + " loaded on the fly?)");
+      if (spigot.getBoolean("settings.restart-on-crash")) {
+        getServer().dispatchCommand(Bukkit.getConsoleSender(), "restart");
+      }
+
+      Bukkit.shutdown();
+      return;
     }
 
-    @Override
-    public void onEnable() {
-        Utilities.instantiate(this);
-        saveDefaultConfig();
-        if (!this.getDataFolder().exists()) {
-        	this.getDataFolder().mkdirs();
-        }
-        reloadConfig();
-        worldGenerator.populate();
-        getServer().getPluginManager().registerEvents(this.blockListener, this);
-        getServer().getPluginManager().registerEvents(this.itemListener, this);
-        getServer().getPluginManager().registerEvents(this.worldGenerator, this);
-        getServer().getPluginManager().registerEvents(this.worldBorderListener, this);
-        protocolBlocker.loadConfig();
-        getServer().getPluginManager().registerEvents(this.protocolBlocker, this);
-        
-        if (getConfig().getDouble("donottouch.configVersion", 0.0f) < localConfigVersion) {
-            log.warning("[Carbon] Please delete your Carbon config and let it regenerate! Yours is outdated and may cause issues with the mod!");
-        }
-
-        if (getServer().getPluginManager().getPlugin("ProtocolLib") != null) {
-	        try {
-	            new ProtocolBlockListener(this).init();
-	            new ProtocolItemListener(this).init();
-	            new ProtocolEntityListener(this).init();
-	        } catch (Throwable t) {
-	        	t.printStackTrace();
-	        }
-        } else {
-            log.info("[Carbon] ProtocolLib not found, not hooking. 1.7 clients not supported.");
-        }
-        
-        if (getServer().getPluginManager().getPlugin("NoCheatPlus") != null) {
-	        try {
-	            new NoCheatPlusSupporter(this).hook();
-	        } catch (Throwable t) {
-	        	t.printStackTrace();
-	        }
-        } else {
-            log.info("[Carbon] NoCheatPlus not found, not hooking.");
-        }
-        
-        log.info("[Carbon] Carbon is enabled.");
+    //inject new blocks
+    try {
+      DynamicEnumType.loadReflection();
+    }
+    catch (NoSuchMethodException | SecurityException | ClassNotFoundException
+        | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+      e.printStackTrace();
     }
 
-    @Override
-    public void onDisable() {
-    	WorldBorder.save();
-    	//call to server shutdown on disable, won't hurt if server already disables itself, but will prevent plugin unload/reload
-    	Bukkit.shutdown();
+    injector = new Injector();
+    injector.registerAll();
+    injector.registerRecipes();
+
+    log.info("Carbon has finished injecting all 1.8 functionalities.");
+  }
+
+  @Override
+  public void onEnable() {
+    Utilities.instantiate(this);
+    saveDefaultConfig();
+    if (!this.getDataFolder().exists()) {
+      this.getDataFolder().mkdirs();
     }
-    
-    //There is no way to reload this plugin safely do to the fact it adds 1.8 blocks into the server.
-  
-    public static Injector injector() {
-        return injector;
+    reloadConfig();
+    worldGenerator.populate();
+    getServer().getPluginManager().registerEvents(blockListener, this);
+    getServer().getPluginManager().registerEvents(commandListener, this);
+    getServer().getPluginManager().registerEvents(itemListener, this);
+    getServer().getPluginManager().registerEvents(worldGenerator, this);
+    getServer().getPluginManager().registerEvents(worldBorderListener, this);
+    protocolBlocker.loadConfig();
+    getServer().getPluginManager().registerEvents(protocolBlocker, this);
+
+    if (getConfig().getDouble("donottouch.configVersion", 0.0f) < localConfigVersion) {
+      log.warning(
+          "Please delete your Carbon config and let it regenerate! Yours is outdated and may cause issues with the mod!");
     }
+
+    if (getServer().getPluginManager().getPlugin("ProtocolLib") != null) {
+      try {
+        new ProtocolBlockListener(this).init();
+        new ProtocolItemListener(this).init();
+        new ProtocolEntityListener(this).init();
+      } catch (Throwable t) {
+        t.printStackTrace();
+      }
+    } else {
+      log.info("ProtocolLib not found, not hooking. 1.7 clients not supported.");
+    }
+    log.info("Carbon is enabled.");
+  }
+
+  @Override
+  public void onDisable() {
+    WorldBorder.save();
+  }
+
+  //There is no way to reload this plugin safely do to the fact it adds 1.8 blocks into the server.
+
+  public static Injector injector() {
+    return injector;
+  }
 
 }

--- a/src/main/java/com/lastabyss/carbon/listeners/CommandListener.java
+++ b/src/main/java/com/lastabyss/carbon/listeners/CommandListener.java
@@ -24,6 +24,7 @@ public class CommandListener implements Listener {
       } else {
         // Call to server shutdown on disable.
         // Won't hurt if server already disables itself, but will prevent plugin unload/reload.
+        Bukkit.getLogger().severe("Stopping server due to reload command!");
         Bukkit.shutdown();
       }
     }
@@ -39,9 +40,9 @@ public class CommandListener implements Listener {
         Bukkit.getLogger().severe("Restarting server due to reload command!");
         event.setCommand("restart");
       } else {
-
         // Call to server shutdown on disable.
         // Won't hurt if server already disables itself, but will prevent plugin unload/reload.
+        Bukkit.getLogger().severe("Stopping server due to reload command!");
         Bukkit.shutdown();
       }
     }

--- a/src/main/java/com/lastabyss/carbon/listeners/CommandListener.java
+++ b/src/main/java/com/lastabyss/carbon/listeners/CommandListener.java
@@ -1,0 +1,49 @@
+package com.lastabyss.carbon.listeners;
+
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.bukkit.event.server.ServerCommandEvent;
+
+import java.io.File;
+
+public class CommandListener implements Listener {
+
+  @EventHandler
+  public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent event) {
+    FileConfiguration spigot = YamlConfiguration.loadConfiguration(new File(Bukkit.getServer().getWorldContainer(), "spigot.yml"));
+
+    if (event.getMessage().equalsIgnoreCase("/reload")) {
+      // Restarts server if server is set up for it.
+      if (spigot.getBoolean("settings.restart-on-crash")) {
+        Bukkit.getLogger().severe("Restarting server due to reload command!");
+        Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), "restart");
+      } else {
+        // Call to server shutdown on disable.
+        // Won't hurt if server already disables itself, but will prevent plugin unload/reload.
+        Bukkit.shutdown();
+      }
+    }
+  }
+
+  @EventHandler
+  public void onServerCommand(ServerCommandEvent event) {
+    FileConfiguration spigot = YamlConfiguration.loadConfiguration(new File(Bukkit.getServer().getWorldContainer(), "spigot.yml"));
+
+    if (event.getCommand().equalsIgnoreCase("reload")) {
+      // Restarts server if server is set up for it.
+      if (spigot.getBoolean("settings.restart-on-crash")) {
+        Bukkit.getLogger().severe("Restarting server due to reload command!");
+        event.setCommand("restart");
+      } else {
+
+        // Call to server shutdown on disable.
+        // Won't hurt if server already disables itself, but will prevent plugin unload/reload.
+        Bukkit.shutdown();
+      }
+    }
+  }
+}

--- a/src/main/java/com/lastabyss/carbon/listeners/WorldBorderListener.java
+++ b/src/main/java/com/lastabyss/carbon/listeners/WorldBorderListener.java
@@ -1,5 +1,10 @@
 package com.lastabyss.carbon.listeners;
 
+import com.lastabyss.carbon.packets.PacketPlayOutWorldBorder;
+import com.lastabyss.carbon.packets.PacketPlayOutWorldBorder.WorldBorderAction;
+import com.lastabyss.carbon.utils.Utilities;
+import com.lastabyss.carbon.worldborder.WorldBorder;
+
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
@@ -9,15 +14,10 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 
-import com.lastabyss.carbon.packets.PacketPlayOutWorldBorder;
-import com.lastabyss.carbon.packets.PacketPlayOutWorldBorder.WorldBorderAction;
-import com.lastabyss.carbon.utils.Utilities;
-import com.lastabyss.carbon.worldborder.WorldBorder;
-
 public class WorldBorderListener implements Listener {
 
 	@EventHandler
-	public void onPayerJoin(PlayerJoinEvent event) {
+	public void onPlayerJoin(PlayerJoinEvent event) {
 		PacketPlayOutWorldBorder packet = new PacketPlayOutWorldBorder(WorldBorder.getInstance(event.getPlayer().getWorld()), WorldBorderAction.INITIALIZE);
 		Utilities.sendPacket(event.getPlayer(), packet);
 	}


### PR DESCRIPTION
Instead of simply stopping the server, the server will not restart if the server has restarting set up.

The server will restart if the following is true in spigot.yml:

```
restart-on-crash: true
```
