### PR TITLE
Change BlockBarrier from Block to BlockHalfTransparent

### DIFF
--- a/src/main/java/com/lastabyss/carbon/blocks/BlockBarrier.java
+++ b/src/main/java/com/lastabyss/carbon/blocks/BlockBarrier.java
@@ -1,13 +1,13 @@
 package com.lastabyss.carbon.blocks;
 
-import net.minecraft.server.v1_7_R4.Block;
+import net.minecraft.server.v1_7_R4.BlockHalfTransparent;
 import net.minecraft.server.v1_7_R4.CreativeModeTab;
 import net.minecraft.server.v1_7_R4.Material;
 
-public class BlockBarrier extends Block {
+public class BlockBarrier extends BlockHalfTransparent {
 
   public BlockBarrier() {
-    super(Material.STONE);
+    super("barrier", Material.BUILDABLE_GLASS, false);
     a(CreativeModeTab.b);
     //Sets infinite hardness.
     s();


### PR DESCRIPTION
Addresses #56

Not sure if this is the proper way to handle barriers - haven't read the source for them - but they seem to function as intended with this change.

Light passes them, blocks that require a solid surface can be placed on them, they can't be mined, moved with pistons or exploded, and they persist across restarts.
