### PR TITLE
Only drop 1 head when a charged creeper kills multiple entities

### DIFF
--- a/src/main/java/com/lastabyss/carbon/listeners/ItemListener.java
+++ b/src/main/java/com/lastabyss/carbon/listeners/ItemListener.java
@@ -45,7 +45,8 @@ public class ItemListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onTeleport(PlayerTeleportEvent e) {
-        if(e.getCause().equals(TeleportCause.ENDER_PEARL) && plugin.getConfig().getBoolean("mobSpawning.endermites", true)) {
+        if (e.getCause() == TeleportCause.ENDER_PEARL && plugin.getConfig().getBoolean("mobSpawning.endermites", true)
+                && e.getTo().getWorld().getAllowMonsters()) {
             Random rand = new Random();
             if(rand.nextInt(100) < 5) {//5% probability of spawning
             	EntityEndermite ender = new EntityEndermite(((CraftWorld) e.getFrom().getWorld()).getHandle());
@@ -56,45 +57,45 @@ public class ItemListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onEntityKilled(EntityDeathEvent e) {
-        if (plugin.getConfig().getBoolean("options.sheep.dropMutton", true)) {
-            if(e.getEntityType().equals(EntityType.SHEEP)) {
-                if(e.getEntity() instanceof Ageable) {
-                    Ageable entity = (Ageable) e.getEntity();
-                    if(entity.isAdult()) {
-                        boolean fireaspect = false;
-                        int looting = 1;
-                        if(entity.getLastDamageCause() instanceof EntityDamageByEntityEvent) {
-                            EntityDamageByEntityEvent dEvent = (EntityDamageByEntityEvent) entity.getLastDamageCause();
-                            if(dEvent.getDamager() != null && dEvent.getDamager() instanceof Player) {
-                                ItemStack hand = ((Player) dEvent.getDamager()).getItemInHand();
-                                fireaspect = hand.containsEnchantment(Enchantment.FIRE_ASPECT);
-                                if(hand.containsEnchantment(Enchantment.LOOT_BONUS_MOBS))
-                                    looting += hand.getEnchantmentLevel(Enchantment.LOOT_BONUS_MOBS);
-                                if(looting < 1) //Incase a plugin sets an enchantment level to be negative
-                                    looting = 1;
-                            } else if(dEvent.getDamager() != null && dEvent.getDamager() instanceof Arrow) {
-                                Arrow a = (Arrow) dEvent.getDamager();
-                                if(a.getFireTicks() > 0)
-                                    fireaspect = true;
-                            }
-                        }
-                        if(entity.getLastDamageCause().getCause().equals(DamageCause.FIRE_TICK) || entity.getLastDamageCause().getCause().equals(DamageCause.FIRE) ||
-                                entity.getLastDamageCause().getCause().equals(DamageCause.LAVA) || fireaspect)
-                            e.getDrops().add(new ItemStack(Carbon.injector().cookedMuttonItemMat, random.nextInt(2) + 1 + random.nextInt(looting)));
-                        else
-                            e.getDrops().add(new ItemStack(Carbon.injector().muttonItemMat, random.nextInt(2) + 1 + random.nextInt(looting)));
-                    }
-                }
+        if (e.getEntity().getType() != EntityType.SHEEP || !plugin.getConfig().getBoolean("options.sheep.dropMutton", true)
+                || !e.getEntity().getWorld().isGameRule("doMobLoot") || !(e.getEntity() instanceof Ageable)) {
+            return;
+        }
+        Ageable entity = (Ageable) e.getEntity();
+        if (!entity.isAdult()) {
+            return;
+        }
+        boolean fireaspect = false;
+        int looting = 1;
+        if (entity.getLastDamageCause() instanceof EntityDamageByEntityEvent) {
+            EntityDamageByEntityEvent dEvent = (EntityDamageByEntityEvent) entity.getLastDamageCause();
+            if (dEvent.getDamager() != null && dEvent.getDamager() instanceof Player) {
+                ItemStack hand = ((Player) dEvent.getDamager()).getItemInHand();
+                fireaspect = hand.containsEnchantment(Enchantment.FIRE_ASPECT);
+                if (hand.containsEnchantment(Enchantment.LOOT_BONUS_MOBS))
+                    looting += hand.getEnchantmentLevel(Enchantment.LOOT_BONUS_MOBS);
+                if (looting < 1) //Incase a plugin sets an enchantment level to be negative
+                    looting = 1;
+            } else if (dEvent.getDamager() != null && dEvent.getDamager() instanceof Arrow) {
+                Arrow a = (Arrow) dEvent.getDamager();
+                if (a.getFireTicks() > 0)
+                    fireaspect = true;
             }
         }
+        if (entity.getLastDamageCause().getCause() == DamageCause.FIRE_TICK || entity.getLastDamageCause().getCause() == DamageCause.FIRE
+                || entity.getLastDamageCause().getCause() == DamageCause.LAVA || fireaspect)
+            e.getDrops().add(new ItemStack(Carbon.injector().cookedMuttonItemMat, random.nextInt(2) + 1 + random.nextInt(looting)));
+        else
+            e.getDrops().add(new ItemStack(Carbon.injector().muttonItemMat, random.nextInt(2) + 1 + random.nextInt(looting)));
     }
 
     @EventHandler
     public void onCreeperDeath(EntityDeathEvent e) {
         LivingEntity entity = e.getEntity();
-        if (entity.getLastDamageCause() == null || entity.getLastDamageCause().getCause() == null
+        if (entity.getLastDamageCause().getCause() != DamageCause.ENTITY_EXPLOSION
                 || !plugin.getConfig().getBoolean("options.creeper.dropMobHead", true)
-                || entity.getLastDamageCause().getCause() != DamageCause.ENTITY_EXPLOSION
+                || !entity.getWorld().isGameRule("doMobLoot")
+                || entity.getLastDamageCause() == null || entity.getLastDamageCause().getCause() == null
                 || !(entity.getLastDamageCause() instanceof EntityDamageByEntityEvent)) return;
         EntityDamageByEntityEvent damageEvent = (EntityDamageByEntityEvent) entity.getLastDamageCause();
         if (damageEvent.getDamager() == null || damageEvent.getDamager().getType() != EntityType.CREEPER

--- a/src/main/java/com/lastabyss/carbon/listeners/ItemListener.java
+++ b/src/main/java/com/lastabyss/carbon/listeners/ItemListener.java
@@ -92,10 +92,10 @@ public class ItemListener implements Listener {
     @EventHandler
     public void onCreeperDeath(EntityDeathEvent e) {
         LivingEntity entity = e.getEntity();
-        if (entity.getLastDamageCause().getCause() != DamageCause.ENTITY_EXPLOSION
+        if (entity.getLastDamageCause() == null || entity.getLastDamageCause().getCause() == null
+                || entity.getLastDamageCause().getCause() != DamageCause.ENTITY_EXPLOSION
                 || !plugin.getConfig().getBoolean("options.creeper.dropMobHead", true)
                 || !entity.getWorld().isGameRule("doMobLoot")
-                || entity.getLastDamageCause() == null || entity.getLastDamageCause().getCause() == null
                 || !(entity.getLastDamageCause() instanceof EntityDamageByEntityEvent)) return;
         EntityDamageByEntityEvent damageEvent = (EntityDamageByEntityEvent) entity.getLastDamageCause();
         if (damageEvent.getDamager() == null || damageEvent.getDamager().getType() != EntityType.CREEPER


### PR DESCRIPTION
Addresses #82
My original idea broke when mobGriefing was false. Creepers also do not appear to fire an event when removed because they exploded, so this became the easiest option to implement.
